### PR TITLE
Add GraphQL schema snapshot

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,7 +12,17 @@ module.exports = {
                 accessToken: process.env.CONTENTFUL_PREVIEW ? process.env.CONTENTFUL_PREVIEW_TOKEN : process.env.CONTENTFUL_DELIVERY_TOKEN,
                 host: process.env.CONTENTFUL_PREVIEW ? 'preview.contentful.com' : 'cdn.contentful.com',
                 useNameForId: false
-            },
+            }
+        },
+        {
+            resolve: 'gatsby-plugin-schema-snapshot',
+            options: {
+                path: 'schema.gql',
+                exclude: {
+                    plugins: ['gatsby-source-npm-package-search']
+                },
+                update: process.env.GATSBY_UPDATE_SCHEMA_SNAPSHOT
+            }
         }
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7935,6 +7935,11 @@
         "sass-loader": "^7.3.1"
       }
     },
+    "gatsby-plugin-schema-snapshot": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-schema-snapshot/-/gatsby-plugin-schema-snapshot-1.0.0.tgz",
+      "integrity": "sha512-Gf/otsntsTPVl/bG2mK/Y2yuYufhm9PFvmV8yMia2KckrFs1jjofPugYUjpBIGm9RDrtYeLCcZhw057GbQrbeA=="
+    },
     "gatsby-plugin-sharp": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gatsby": "2.19.16",
     "gatsby-plugin-react-helmet": "^3.1.22",
     "gatsby-plugin-sass": "^2.1.28",
+    "gatsby-plugin-schema-snapshot": "^1.0.0",
     "gatsby-source-contentful": "^2.1.85",
     "lodash": "^4.17.15",
     "marked": "^0.8.0",

--- a/schema.gql
+++ b/schema.gql
@@ -1,0 +1,986 @@
+### Type definitions saved at 2020-04-06T10:35:43.058Z ###
+
+type File implements Node @dontInfer {
+  sourceInstanceName: String!
+  absolutePath: String!
+  relativePath: String!
+  extension: String!
+  size: Int!
+  prettySize: String!
+  modifiedTime: Date! @dateformat
+  accessTime: Date! @dateformat
+  changeTime: Date! @dateformat
+  birthTime: Date! @dateformat
+  root: String!
+  dir: String!
+  base: String!
+  ext: String!
+  name: String!
+  relativeDirectory: String!
+  dev: Int!
+  mode: Int!
+  nlink: Int!
+  uid: Int!
+  gid: Int!
+  rdev: Int!
+  ino: Float!
+  atimeMs: Float!
+  mtimeMs: Float!
+  ctimeMs: Float!
+  atime: Date! @dateformat
+  mtime: Date! @dateformat
+  ctime: Date! @dateformat
+  birthtime: Date @deprecated(reason: "Use `birthTime` instead")
+  birthtimeMs: Float @deprecated(reason: "Use `birthTime` instead")
+}
+
+type Directory implements Node @dontInfer {
+  sourceInstanceName: String!
+  absolutePath: String!
+  relativePath: String!
+  extension: String!
+  size: Int!
+  prettySize: String!
+  modifiedTime: Date! @dateformat
+  accessTime: Date! @dateformat
+  changeTime: Date! @dateformat
+  birthTime: Date! @dateformat
+  root: String!
+  dir: String!
+  base: String!
+  ext: String!
+  name: String!
+  relativeDirectory: String!
+  dev: Int!
+  mode: Int!
+  nlink: Int!
+  uid: Int!
+  gid: Int!
+  rdev: Int!
+  ino: Float!
+  atimeMs: Float!
+  mtimeMs: Float!
+  ctimeMs: Float!
+  atime: Date! @dateformat
+  mtime: Date! @dateformat
+  ctime: Date! @dateformat
+  birthtime: Date @deprecated(reason: "Use `birthTime` instead")
+  birthtimeMs: Float @deprecated(reason: "Use `birthTime` instead")
+}
+
+type SitePage implements Node @dontInfer {
+  path: String!
+  component: String!
+  internalComponentName: String!
+  componentChunkName: String!
+  matchPath: String
+}
+
+type StackbitInternal implements Node @dontInfer {
+  updateTime: Float
+}
+
+type ContentfulAsset implements Node @derivedTypes @dontInfer {
+  contentful_id: String
+  file: ContentfulAssetFile
+  title: String
+  description: String
+  node_locale: String
+}
+
+type ContentfulAssetFile @derivedTypes {
+  url: String
+  details: ContentfulAssetFileDetails
+  fileName: String
+  contentType: String
+}
+
+type ContentfulAssetFileDetails @derivedTypes {
+  size: Int
+  image: ContentfulAssetFileDetailsImage
+}
+
+type ContentfulAssetFileDetailsImage {
+  width: Int
+  height: Int
+}
+
+type contentfulSectionReviewsSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type contentfulSectionReviewsTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionReviewsSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type ContentfulSectionReviews implements Node @derivedTypes @dontInfer {
+  bg: String
+  reviews: [ContentfulSectionReviewsReviews] @link(by: "id", from: "reviews___NODE")
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionReviewsSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionReviewsTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionReviewsSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionReviewsSys
+  node_locale: String
+}
+
+type ContentfulSectionReviewsReviews implements Node @derivedTypes @dontInfer {
+  avatar: ContentfulAsset @link(by: "id", from: "avatar___NODE")
+  section_reviews: [ContentfulSectionReviews] @link(by: "id", from: "section_reviews___NODE")
+  author: contentfulSectionReviewsReviewsAuthorTextNode @link(by: "id", from: "author___NODE")
+  content: contentfulSectionReviewsReviewsContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionReviewsReviewsSys
+  node_locale: String
+}
+
+type contentfulSectionReviewsReviewsAuthorTextNode implements Node @dontInfer {
+  author: String
+}
+
+type contentfulSectionReviewsReviewsContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type ContentfulSectionReviewsReviewsSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionReviewsReviewsSysContentType
+}
+
+type ContentfulSectionReviewsReviewsSysContentType @derivedTypes {
+  sys: ContentfulSectionReviewsReviewsSysContentTypeSys
+}
+
+type ContentfulSectionReviewsReviewsSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulLanding implements Node @derivedTypes @dontInfer {
+  slug: String
+  sections: [ContentfulSectionContactContentfulSectionContentContentfulSectionCtaContentfulSectionFaqContentfulSectionFeaturesContentfulSectionHeroContentfulSectionPostsContentfulSectionPricingContentfulSectionReviewsUnion] @link(by: "id", from: "sections___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulLandingSys
+  node_locale: String
+  title: contentfulLandingTitleTextNode @link(by: "id", from: "title___NODE")
+}
+
+union ContentfulSectionContactContentfulSectionContentContentfulSectionCtaContentfulSectionFaqContentfulSectionFeaturesContentfulSectionHeroContentfulSectionPostsContentfulSectionPricingContentfulSectionReviewsUnion = ContentfulSectionContact | ContentfulSectionContent | ContentfulSectionCta | ContentfulSectionFaq | ContentfulSectionFeatures | ContentfulSectionHero | ContentfulSectionPosts | ContentfulSectionPricing | ContentfulSectionReviews
+
+type ContentfulLandingSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulLandingSysContentType
+}
+
+type ContentfulLandingSysContentType @derivedTypes {
+  sys: ContentfulLandingSysContentTypeSys
+}
+
+type ContentfulLandingSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulLandingTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulSectionReviewsSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionReviewsSysContentType
+}
+
+type ContentfulSectionReviewsSysContentType @derivedTypes {
+  sys: ContentfulSectionReviewsSysContentTypeSys
+}
+
+type ContentfulSectionReviewsSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulSectionPricingPricingplansDetailsTextNode implements Node @dontInfer {
+  details: String
+}
+
+type contentfulSectionPricingPricingplansPriceTextNode implements Node @dontInfer {
+  price: String
+}
+
+type contentfulSectionPricingPricingplansTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulSectionPricingPricingplans implements Node @derivedTypes @dontInfer {
+  actions: [ContentfulAction] @link(by: "id", from: "actions___NODE")
+  section_pricing: [ContentfulSectionPricing] @link(by: "id", from: "section_pricing___NODE")
+  title: contentfulSectionPricingPricingplansTitleTextNode @link(by: "id", from: "title___NODE")
+  price: contentfulSectionPricingPricingplansPriceTextNode @link(by: "id", from: "price___NODE")
+  details: contentfulSectionPricingPricingplansDetailsTextNode @link(by: "id", from: "details___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionPricingPricingplansSys
+  node_locale: String
+  highlight: Boolean
+}
+
+type ContentfulAction implements Node @derivedTypes @dontInfer {
+  primary: Boolean
+  new_window: Boolean
+  section_content: [ContentfulSectionContent] @link(by: "id", from: "section_content___NODE")
+  label: contentfulActionLabelTextNode @link(by: "id", from: "label___NODE")
+  url: contentfulActionUrlTextNode @link(by: "id", from: "url___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulActionSys
+  node_locale: String
+  config_header: [ContentfulConfigHeader] @link(by: "id", from: "config_header___NODE")
+  section_hero: [ContentfulSectionHero] @link(by: "id", from: "section_hero___NODE")
+  config_footer: [ContentfulConfigFooter] @link(by: "id", from: "config_footer___NODE")
+  section_cta: [ContentfulSectionCta] @link(by: "id", from: "section_cta___NODE")
+  section_features_featureslist: [ContentfulSectionFeaturesFeatureslist] @link(by: "id", from: "section_features_featureslist___NODE")
+  section_pricing_pricingplans: [ContentfulSectionPricingPricingplans] @link(by: "id", from: "section_pricing_pricingplans___NODE")
+}
+
+type ContentfulSectionContent implements Node @derivedTypes @dontInfer {
+  bg: String
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionContentSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionContentTitleTextNode @link(by: "id", from: "title___NODE")
+  content: contentfulSectionContentContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionContentSys
+  node_locale: String
+  actions: [ContentfulAction] @link(by: "id", from: "actions___NODE")
+  image: ContentfulAsset @link(by: "id", from: "image___NODE")
+}
+
+type contentfulSectionContentSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type contentfulSectionContentTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionContentContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type ContentfulSectionContentSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionContentSysContentType
+}
+
+type ContentfulSectionContentSysContentType @derivedTypes {
+  sys: ContentfulSectionContentSysContentTypeSys
+}
+
+type ContentfulSectionContentSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulActionLabelTextNode implements Node @dontInfer {
+  label: String
+}
+
+type contentfulActionUrlTextNode implements Node @dontInfer {
+  url: String
+}
+
+type ContentfulActionSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulActionSysContentType
+}
+
+type ContentfulActionSysContentType @derivedTypes {
+  sys: ContentfulActionSysContentTypeSys
+}
+
+type ContentfulActionSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulConfigHeader implements Node @derivedTypes @dontInfer {
+  has_nav: Boolean
+  logo_img: ContentfulAsset @link(by: "id", from: "logo_img___NODE")
+  nav_links: [ContentfulAction] @link(by: "id", from: "nav_links___NODE")
+  config: [ContentfulConfig] @link(by: "id", from: "config___NODE")
+  title: contentfulConfigHeaderTitleTextNode @link(by: "id", from: "title___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulConfigHeaderSys
+  node_locale: String
+}
+
+type ContentfulConfig implements Node @derivedTypes @dontInfer {
+  palette: String
+  header: ContentfulConfigHeader @link(by: "id", from: "header___NODE")
+  footer: ContentfulConfigFooter @link(by: "id", from: "footer___NODE")
+  title: contentfulConfigTitleTextNode @link(by: "id", from: "title___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulConfigSys
+  node_locale: String
+}
+
+type ContentfulConfigFooter implements Node @derivedTypes @dontInfer {
+  has_nav: Boolean
+  has_social: Boolean
+  has_subscribe: Boolean
+  logo_img: ContentfulAsset @link(by: "id", from: "logo_img___NODE")
+  nav_links: [ContentfulAction] @link(by: "id", from: "nav_links___NODE")
+  social_links: [ContentfulAction] @link(by: "id", from: "social_links___NODE")
+  links: [ContentfulAction] @link(by: "id", from: "links___NODE")
+  config: [ContentfulConfig] @link(by: "id", from: "config___NODE")
+  tagline: contentfulConfigFooterTaglineTextNode @link(by: "id", from: "tagline___NODE")
+  nav_title: contentfulConfigFooterNavTitleTextNode @link(by: "id", from: "nav_title___NODE")
+  social_title: contentfulConfigFooterSocialTitleTextNode @link(by: "id", from: "social_title___NODE")
+  subscribe_title: contentfulConfigFooterSubscribeTitleTextNode @link(by: "id", from: "subscribe_title___NODE")
+  subscribe_content: contentfulConfigFooterSubscribeContentTextNode @link(by: "id", from: "subscribe_content___NODE")
+  content: contentfulConfigFooterContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulConfigFooterSys
+  node_locale: String
+}
+
+type contentfulConfigFooterTaglineTextNode implements Node @dontInfer {
+  tagline: String
+}
+
+type contentfulConfigFooterNavTitleTextNode implements Node @dontInfer {
+  nav_title: String
+}
+
+type contentfulConfigFooterSocialTitleTextNode implements Node @dontInfer {
+  social_title: String
+}
+
+type contentfulConfigFooterSubscribeTitleTextNode implements Node @dontInfer {
+  subscribe_title: String
+}
+
+type contentfulConfigFooterSubscribeContentTextNode implements Node @dontInfer {
+  subscribe_content: String
+}
+
+type contentfulConfigFooterContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type ContentfulConfigFooterSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulConfigFooterSysContentType
+}
+
+type ContentfulConfigFooterSysContentType @derivedTypes {
+  sys: ContentfulConfigFooterSysContentTypeSys
+}
+
+type ContentfulConfigFooterSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulConfigTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulConfigSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulConfigSysContentType
+}
+
+type ContentfulConfigSysContentType @derivedTypes {
+  sys: ContentfulConfigSysContentTypeSys
+}
+
+type ContentfulConfigSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulConfigHeaderTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulConfigHeaderSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulConfigHeaderSysContentType
+}
+
+type ContentfulConfigHeaderSysContentType @derivedTypes {
+  sys: ContentfulConfigHeaderSysContentTypeSys
+}
+
+type ContentfulConfigHeaderSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulSectionHero implements Node @derivedTypes @dontInfer {
+  image: ContentfulAsset @link(by: "id", from: "image___NODE")
+  actions: [ContentfulAction] @link(by: "id", from: "actions___NODE")
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionHeroSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionHeroTitleTextNode @link(by: "id", from: "title___NODE")
+  content: contentfulSectionHeroContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionHeroSys
+  node_locale: String
+}
+
+type contentfulSectionHeroSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type contentfulSectionHeroTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionHeroContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type ContentfulSectionHeroSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionHeroSysContentType
+}
+
+type ContentfulSectionHeroSysContentType @derivedTypes {
+  sys: ContentfulSectionHeroSysContentTypeSys
+}
+
+type ContentfulSectionHeroSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulSectionCta implements Node @derivedTypes @dontInfer {
+  actions: [ContentfulAction] @link(by: "id", from: "actions___NODE")
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionCtaSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionCtaTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionCtaSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionCtaSys
+  node_locale: String
+}
+
+type contentfulSectionCtaSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type contentfulSectionCtaTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionCtaSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type ContentfulSectionCtaSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionCtaSysContentType
+}
+
+type ContentfulSectionCtaSysContentType @derivedTypes {
+  sys: ContentfulSectionCtaSysContentTypeSys
+}
+
+type ContentfulSectionCtaSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulSectionFeaturesFeatureslist implements Node @derivedTypes @dontInfer {
+  image: ContentfulAsset @link(by: "id", from: "image___NODE")
+  actions: [ContentfulAction] @link(by: "id", from: "actions___NODE")
+  section_features: [ContentfulSectionFeatures] @link(by: "id", from: "section_features___NODE")
+  title: contentfulSectionFeaturesFeatureslistTitleTextNode @link(by: "id", from: "title___NODE")
+  content: contentfulSectionFeaturesFeatureslistContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionFeaturesFeatureslistSys
+  node_locale: String
+}
+
+type ContentfulSectionFeatures implements Node @derivedTypes @dontInfer {
+  bg: String
+  featureslist: [ContentfulSectionFeaturesFeatureslist] @link(by: "id", from: "featureslist___NODE")
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionFeaturesSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionFeaturesTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionFeaturesSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionFeaturesSys
+  node_locale: String
+}
+
+type contentfulSectionFeaturesSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type contentfulSectionFeaturesTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionFeaturesSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type ContentfulSectionFeaturesSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionFeaturesSysContentType
+}
+
+type ContentfulSectionFeaturesSysContentType @derivedTypes {
+  sys: ContentfulSectionFeaturesSysContentTypeSys
+}
+
+type ContentfulSectionFeaturesSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulSectionFeaturesFeatureslistTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionFeaturesFeatureslistContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type ContentfulSectionFeaturesFeatureslistSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionFeaturesFeatureslistSysContentType
+}
+
+type ContentfulSectionFeaturesFeatureslistSysContentType @derivedTypes {
+  sys: ContentfulSectionFeaturesFeatureslistSysContentTypeSys
+}
+
+type ContentfulSectionFeaturesFeatureslistSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulSectionPricing implements Node @derivedTypes @dontInfer {
+  bg: String
+  pricingplans: [ContentfulSectionPricingPricingplans] @link(by: "id", from: "pricingplans___NODE")
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionPricingSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionPricingTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionPricingSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionPricingSys
+  node_locale: String
+}
+
+type contentfulSectionPricingSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type contentfulSectionPricingTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionPricingSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type ContentfulSectionPricingSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionPricingSysContentType
+}
+
+type ContentfulSectionPricingSysContentType @derivedTypes {
+  sys: ContentfulSectionPricingSysContentTypeSys
+}
+
+type ContentfulSectionPricingSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulSectionPricingPricingplansSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionPricingPricingplansSysContentType
+}
+
+type ContentfulSectionPricingPricingplansSysContentType @derivedTypes {
+  sys: ContentfulSectionPricingPricingplansSysContentTypeSys
+}
+
+type ContentfulSectionPricingPricingplansSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulSectionPostsSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type contentfulSectionPostsTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionPostsSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type ContentfulSectionPosts implements Node @derivedTypes @dontInfer {
+  bg: String
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+  section_id: contentfulSectionPostsSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionPostsTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionPostsSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionPostsSys
+  node_locale: String
+}
+
+type ContentfulSectionPostsSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionPostsSysContentType
+}
+
+type ContentfulSectionPostsSysContentType @derivedTypes {
+  sys: ContentfulSectionPostsSysContentTypeSys
+}
+
+type ContentfulSectionPostsSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulSectionFaqSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type contentfulSectionFaqTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionFaqSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type ContentfulSectionFaq implements Node @derivedTypes @dontInfer {
+  bg: String
+  section_id: contentfulSectionFaqSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionFaqTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionFaqSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionFaqSys
+  node_locale: String
+  faqitems: [ContentfulSectionFaqFaqitems] @link(by: "id", from: "faqitems___NODE")
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+}
+
+type ContentfulSectionFaqSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionFaqSysContentType
+}
+
+type ContentfulSectionFaqSysContentType @derivedTypes {
+  sys: ContentfulSectionFaqSysContentTypeSys
+}
+
+type ContentfulSectionFaqSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulSectionFaqFaqitems implements Node @derivedTypes @dontInfer {
+  section_faq: [ContentfulSectionFaq] @link(by: "id", from: "section_faq___NODE")
+  question: contentfulSectionFaqFaqitemsQuestionTextNode @link(by: "id", from: "question___NODE")
+  answer: contentfulSectionFaqFaqitemsAnswerTextNode @link(by: "id", from: "answer___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionFaqFaqitemsSys
+  node_locale: String
+}
+
+type contentfulSectionFaqFaqitemsQuestionTextNode implements Node @dontInfer {
+  question: String
+}
+
+type contentfulSectionFaqFaqitemsAnswerTextNode implements Node @dontInfer {
+  answer: String
+}
+
+type ContentfulSectionFaqFaqitemsSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulSectionFaqFaqitemsSysContentType
+}
+
+type ContentfulSectionFaqFaqitemsSysContentType @derivedTypes {
+  sys: ContentfulSectionFaqFaqitemsSysContentTypeSys
+}
+
+type ContentfulSectionFaqFaqitemsSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulPostContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type contentfulPostExcerptTextNode implements Node @dontInfer {
+  excerpt: String
+}
+
+type contentfulPostSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type contentfulPostTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulPost implements Node @derivedTypes @dontInfer {
+  slug: String
+  date: Date @dateformat
+  thumb_img_path: ContentfulAsset @link(by: "id", from: "thumb_img_path___NODE")
+  img_path: ContentfulAsset @link(by: "id", from: "img_path___NODE")
+  title: contentfulPostTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulPostSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  excerpt: contentfulPostExcerptTextNode @link(by: "id", from: "excerpt___NODE")
+  content: contentfulPostContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulPostSys
+  node_locale: String
+}
+
+type ContentfulPostSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulPostSysContentType
+}
+
+type ContentfulPostSysContentType @derivedTypes {
+  sys: ContentfulPostSysContentTypeSys
+}
+
+type ContentfulPostSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulSectionContactContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type contentfulSectionContactSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type contentfulSectionContactTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type contentfulSectionContactSectionIdTextNode implements Node @dontInfer {
+  section_id: String
+}
+
+type ContentfulSectionContact implements Node @derivedTypes @dontInfer {
+  bg: String
+  section_id: contentfulSectionContactSectionIdTextNode @link(by: "id", from: "section_id___NODE")
+  title: contentfulSectionContactTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulSectionContactSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  content: contentfulSectionContactContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulSectionContactSys
+  node_locale: String
+  landing: [ContentfulLanding] @link(by: "id", from: "landing___NODE")
+}
+
+type ContentfulSectionContactSys @derivedTypes {
+  contentType: ContentfulSectionContactSysContentType
+  revision: Int
+}
+
+type ContentfulSectionContactSysContentType @derivedTypes {
+  sys: ContentfulSectionContactSysContentTypeSys
+}
+
+type ContentfulSectionContactSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulPageContentTextNode implements Node @dontInfer {
+  content: String
+}
+
+type contentfulPageSubtitleTextNode implements Node @dontInfer {
+  subtitle: String
+}
+
+type contentfulPageTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulPage implements Node @derivedTypes @dontInfer {
+  slug: String
+  title: contentfulPageTitleTextNode @link(by: "id", from: "title___NODE")
+  subtitle: contentfulPageSubtitleTextNode @link(by: "id", from: "subtitle___NODE")
+  content: contentfulPageContentTextNode @link(by: "id", from: "content___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulPageSys
+  node_locale: String
+  img_path: ContentfulAsset @link(by: "id", from: "img_path___NODE")
+}
+
+type ContentfulPageSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulPageSysContentType
+}
+
+type ContentfulPageSysContentType @derivedTypes {
+  sys: ContentfulPageSysContentTypeSys
+}
+
+type ContentfulPageSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type contentfulBlogTitleTextNode implements Node @dontInfer {
+  title: String
+}
+
+type ContentfulBlog implements Node @derivedTypes @dontInfer {
+  slug: String
+  title: contentfulBlogTitleTextNode @link(by: "id", from: "title___NODE")
+  spaceId: String
+  contentful_id: String
+  createdAt: Date @dateformat
+  updatedAt: Date @dateformat
+  sys: ContentfulBlogSys
+  node_locale: String
+}
+
+type ContentfulBlogSys @derivedTypes {
+  revision: Int
+  contentType: ContentfulBlogSysContentType
+}
+
+type ContentfulBlogSysContentType @derivedTypes {
+  sys: ContentfulBlogSysContentTypeSys
+}
+
+type ContentfulBlogSysContentTypeSys {
+  type: String
+  linkType: String
+  id: String
+  contentful_id: String
+}
+
+type ContentfulContentType implements Node @dontInfer {
+  name: String
+  displayField: String
+  description: String
+}


### PR DESCRIPTION
This PR fixes an issue where emptying a field that is used in one of the templates will cause a fatal Gatsby error.

The issue is described in https://github.com/gatsbyjs/gatsby/issues/1517 and https://github.com/gatsbyjs/gatsby/issues/2881. The proposed solution, described in https://github.com/gatsbyjs/gatsby/pull/16291, is to add the [gatsby-plugin-schema-snapshot plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-schema-snapshot/). This PR does just that.